### PR TITLE
drop unused parameters from forth2 package

### DIFF
--- a/src/main/scala/Forth2.scala
+++ b/src/main/scala/Forth2.scala
@@ -15,7 +15,6 @@ final case class Push(value: Int) extends ForthOperators[Unit]
 final case object Add extends ForthOperators[Unit]
 final case object Mul extends ForthOperators[Unit]
 final case object Dup extends ForthOperators[Unit]
-final case object End extends ForthOperators[Unit]
 
 
 object Forth {
@@ -28,7 +27,6 @@ object Forth {
   def add = Add
   def mul = Mul
   def dup = Dup
-  def end = End
 }
 
 
@@ -56,10 +54,6 @@ object Transforms {
           val a :: tail = stack
           (a :: a :: tail, ())
         })
-      case End =>
-        // This doesn't work as intended there may not
-        // be a way to do this using ~>
-        State((a : Stack) => (a, ()))
     }
   }
 
@@ -75,8 +69,6 @@ object Transforms {
         println("Mul")
       case Dup =>
         println("Dup")
-      case End =>
-        println("End")
     }
   }
 

--- a/src/main/scala/Forth2.scala
+++ b/src/main/scala/Forth2.scala
@@ -109,7 +109,11 @@ object test  {
 
     // Using Natural Transformations
     import Transforms.runProgram
-    println(Free.runFC(testProg)(runProgram).exec(List[Int]()))
+
+    def runWithEmptyStack(p: ForthProg[Unit]): List[Int] =
+      Free.runFC(p)(runProgram).exec(Nil)
+
+    println(runWithEmptyStack(testProg))
 
   }
 }


### PR DESCRIPTION
Feel free to email me if you want to discuss it more.
I didn't clean up the `forth` package because I don't think the functor makes sense there given that there's really no data to operate on apart from the stack.   (Not sure it makes sense in forth2 either, but at least there we're using someone else's for free :smile: )

Hope I'm not stepping on any toes!
